### PR TITLE
Enhance Authentication

### DIFF
--- a/Sources/RFBKit/Authenticator.swift
+++ b/Sources/RFBKit/Authenticator.swift
@@ -11,20 +11,26 @@ import Crypto
 public enum AuthenticationType: Equatable {
     public var value: UInt8 {
         switch self {
-        case .ard: return 30
-        case .vncAuth: return 2
+        case .invalid:          return 0
+        case .none:             return 1
+        case .vncAuth:          return 2
+        case .ard:              return 30
         case let .other(value): return value
         }
     }
     
-    case ard
+    case invalid
+    case none
     case vncAuth
+    case ard
     case other(UInt8)
     
     init(value: UInt8) {
         switch value {
-        case 30: self = .ard
+        case 0: self = .invalid
+        case 1: self = .none
         case 2: self = .vncAuth
+        case 30: self = .ard
         default:
             self = .other(value)
         }
@@ -32,10 +38,14 @@ public enum AuthenticationType: Equatable {
     
     func makeAuthenticator(inputStream: InputStream, outputStream: OutputStream) -> Authenticator? {
         switch self {
-        case .ard:
-            return AppleAuthenticator(inputStream: inputStream, outputStream: outputStream)
+        case .invalid:
+            return nil
+        case .none:
+            return NoneAuthenticator(inputStream: inputStream, outputStream: outputStream)
         case .vncAuth:
             return VNCAuthenticator(inputStream: inputStream, outputStream: outputStream)
+        case .ard:
+            return AppleAuthenticator(inputStream: inputStream, outputStream: outputStream)
         case .other(let uInt8):
             print("No Authenticator available for: \(uInt8)")
             return nil
@@ -51,8 +61,27 @@ public enum AuthenticationStatus: Int {
     case connected = 0, wrongPassword = 1, tooManyAttemts = 2, unknown = 255
 }
 
-public protocol Authenticator {
+public protocol Authenticatable {
     func getAuthStatus() -> AuthenticationStatus
+}
+
+internal protocol Authenticator: Authenticatable {
+    var inputStream: InputStream { get }
+    var outputStream: OutputStream { get }
+}
+
+extension Authenticator {
+    public func getAuthStatus() -> AuthenticationStatus {
+        guard let result = inputStream.readUInt32(), let status = AuthenticationStatus(rawValue: Int(result)) else {
+            return .unknown
+        }
+        
+        return status
+    }
+}
+
+enum ARDError: Error {
+    case noSharedSecret, noPublicKey
 }
 
 public class AppleAuthenticator: Authenticator {
@@ -64,25 +93,23 @@ public class AppleAuthenticator: Authenticator {
         self.outputStream = outputStream
     }
     
-    public func authenticate(username: String, password: String) {
-        guard inputStream.hasBytesAvailable else { fatalError("No bytes to atuhenticate!") }
+    public func authenticate(username: String, password: String) throws {
         
-        guard let generator = inputStream.readData(maxLength: 2),
+        guard inputStream.hasBytesAvailable,
+              let generator = inputStream.readData(maxLength: 2),
               let keyLength = inputStream.readUInt16(),
               let primeMod = inputStream.readData(maxLength: Int(keyLength)),
               let serverPubKey = inputStream.readData(maxLength: Int(keyLength)) else {
-                  fatalError("Error reading server data")
+                  throw RFBError.badStream
               }
         
-        print("Auth parameters set")
-        
         let dh = DiffieHellman(p: primeMod, g: generator)
-        guard let sharedSecret = dh.computeSharedSecret(withPublicKey: serverPubKey), let publicKey = dh.publicKey else {
-            return
-            //throws
+        
+        guard let sharedSecret = dh.computeSharedSecret(withPublicKey: serverPubKey) else {
+            throw ARDError.noSharedSecret
         }
         
-        print("secret / pubKey", sharedSecret.base64EncodedString(), publicKey.base64EncodedString())
+        guard let publicKey = dh.publicKey else { throw ARDError.noPublicKey }
         
         var credData = Data(username.utf8) + Data(count: 1)
         while credData.count < 64 {
@@ -94,37 +121,19 @@ public class AppleAuthenticator: Authenticator {
             credData.append(UInt8.random(in: 0...255))
         }
         
-        print("CredData ClearTxt: ", credData.base64EncodedString())
-        
         let encKey = sharedSecret.md5()
-        print("encMD5:", encKey.base64EncodedString())
         
-        do {
-            let cypher = try AESCipher(key: encKey, iv: Data(), blockMode: .ecb)
-            let encCred = try cypher.encrypt(data: credData)
-            
-            let response = encCred + publicKey
-            print("sending", response)
-            outputStream.write(data: response)
-            
-        } catch {
-            print("err:", error.localizedDescription)
-        }
-    }
-    
-    public func getAuthStatus() -> AuthenticationStatus {
-        guard let result = inputStream.readUInt32(), let status = AuthenticationStatus(rawValue: Int(result)) else {
-            return .unknown
-        }
+        let cypher = try AESCipher(key: encKey, iv: Data(), blockMode: .ecb)
+        let encCred = try cypher.encrypt(data: credData)
         
-        return status
+        let response = encCred + publicKey
+        
+        outputStream.write(data: response)
     }
 }
 
+///[UNTESTED]
 public class VNCAuthenticator: Authenticator {
-    public func getAuthStatus() -> AuthenticationStatus {
-        return .connected
-    }
     
     internal let inputStream: InputStream
     internal let outputStream: OutputStream
@@ -134,7 +143,52 @@ public class VNCAuthenticator: Authenticator {
         self.outputStream = outputStream
     }
     
-    public func authenticate(username: String?, password: String?) {
+    private func reverseBits(in password: String) -> Data {
+        var result = Data()
+        let pwBytes = [UInt8](password.utf8)
         
+        for i in 0..<8 {
+            if i < pwBytes.count {
+                var byte = pwBytes[i]
+                byte = (byte & 0xF0) >> 4 | (byte & 0x0F) << 4
+                byte = (byte & 0xCC) >> 2 | (byte & 0x33) << 2
+                byte = (byte & 0xAA) >> 1 | (byte & 0x55) << 1
+                result.append(byte)
+            } else {
+                result.append(0)
+            }
+        }
+        
+        return result
     }
+    
+    public func authenticate(password: String) throws {
+//        assert inputStream.readInt32() == 2 aka VNC Auth type (?), for older versions mby...
+        guard let challenge = inputStream.readData(maxLength: 16) else {
+            throw RFBError.badStream
+        }
+        let key = reverseBits(in: password)
+        
+        //Each 8 bytes of the challenge is encrypted independently (i.e. ECB mode) and sent back to the server
+        let c1 = challenge[..<8]
+        let c2 = challenge[8...]
+        
+        let enc1 = try DES.encrypt(c1, with: key, options: [.pkcs7Padding, .ecbMode])
+        let enc2 = try DES.encrypt(c2, with: key, options: [.pkcs7Padding, .ecbMode])
+        
+        let result = enc1 + enc2
+        
+        outputStream.write(data: result)
+    }
+}
+
+///[UNTESTED]
+public class NoneAuthenticator: Authenticator {
+    internal init(inputStream: InputStream, outputStream: OutputStream) {
+        self.inputStream = inputStream
+        self.outputStream = outputStream
+    }
+    
+    var inputStream: InputStream
+    var outputStream: OutputStream
 }

--- a/Sources/RFBKit/Crypto/DES.swift
+++ b/Sources/RFBKit/Crypto/DES.swift
@@ -1,0 +1,64 @@
+//
+//  DES.swift
+//  
+//
+//  Created by Henrik Storch on 22.06.21.
+//
+
+import Foundation
+import CommonCrypto
+
+struct DESOptions: OptionSet {
+    var rawValue: Int
+    
+    init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    public static var ecbMode = DESOptions(rawValue: kCCOptionECBMode)
+    public static var pkcs7Padding = DESOptions(rawValue: kCCOptionPKCS7Padding)
+}
+
+enum DESError: Error {
+    case operationFailed
+}
+
+class DES: NSObject {
+    static func encrypt(_ input: Data, with key: Data, options: DESOptions) throws -> Data  {
+        
+        let keyLength       = kCCKeySizeDES
+        var bufferData      = Data(count: input.count + kCCBlockSizeDES)
+        var bytesEncrypted  = 0
+        var status          = CCCryptorStatus(0)
+        
+        // Perform operation
+        key.withUnsafeBytes { keyBytes in
+            input.withUnsafeBytes { inputBytes in
+                bufferData.withUnsafeMutableBytes { bufferBytes in
+                    status = CCCrypt(
+                        CCOperation(kCCEncrypt),                  // Operation
+                        CCAlgorithm(kCCAlgorithmDES),    // Algorithm
+                        CCOptions(options.rawValue),  // Options
+                        keyBytes.baseAddress!,      // key data
+                        keyLength,                  // key length
+                        nil,        // IV buffer
+                        inputBytes.baseAddress!,    // input data
+                        inputBytes.count,           // input length
+                        bufferBytes.baseAddress,    // output buffer
+                        bufferBytes.count,          // output buffer length
+                        &bytesEncrypted             // output bytes decrypted real length
+                    )
+                }
+            }
+        }
+        
+        if (status == kCCSuccess) {
+            bufferData.count = bytesEncrypted // Adjust buffer size to real bytes
+            return bufferData
+        } else {
+            print("[ERROR] failed to encrypt|CCCryptoStatus:", status)
+        }
+        
+        throw DESError.operationFailed
+    }
+}


### PR DESCRIPTION
All this wasn't tested IRL with VNC cuz macOS 11 only allows apple auth types (30-36).

- VNC Auth
  - DES encryptor
- None & Invalid Auth
- Error handling